### PR TITLE
Chore: divided work in two jobs and now we build only two times

### DIFF
--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -10,22 +10,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
 
-  lint:
-    runs-on: ubuntu-latest
-
-      # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-        # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14'
-
-        # Runs a single command using the runners shell
-      - name: Lints the project
-        run: npm run lint
-
-  build-and-test:
+  build-lint-and-test:
     runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -39,6 +24,10 @@ jobs:
       # Runs a single command using the runners shell
       - name: Installs needed packages using npm
         run: npm i
+
+      # Runs a single command using the runners shell
+      - name: Lints the project
+        run: npm run lint
 
       # Runs a single command using the runners shell
       - name: Tests the project

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -36,7 +36,7 @@ jobs:
   build-and-coverage:
     runs-on: ubuntu-latest
 
-    needs: build-and-test
+    needs: build-lint-and-test
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Lints the project
         run: npm run lint
 
-  build and test:
+  build-and-test:
     runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -46,7 +46,7 @@ jobs:
       - name: Tests the project
         run: npm run test
 
-  build and coverage:
+  build-and-coverage:
     runs-on: ubuntu-latest
 
     needs: test

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -10,21 +10,6 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
 
-  build:
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14'
-
-      # Runs a single command using the runners shell
-      - name: Installs needed packages using npm
-        run: npm i
-
   lint:
     runs-on: ubuntu-latest
 
@@ -39,36 +24,29 @@ jobs:
           node-version: '14'
 
         # Runs a single command using the runners shell
-      - name: Installs needed packages using npm
-        run: npm i
-
-        # Runs a single command using the runners shell
       - name: Lints the project
         run: npm run lint
 
-  test:
+  build and test:
     runs-on: ubuntu-latest
 
-    needs: build
-
-      # Steps represent a sequence of tasks that will be executed as part of the job
+    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-        # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: '14'
 
-
-        # Runs a single command using the runners shell
+      # Runs a single command using the runners shell
       - name: Installs needed packages using npm
         run: npm i
 
-        # Runs a single command using the runners shell
+      # Runs a single command using the runners shell
       - name: Tests the project
         run: npm run test
 
-  coverage:
+  build and coverage:
     runs-on: ubuntu-latest
 
     needs: test

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -13,8 +13,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
 
-    needs: build
-
       # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
         # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -49,7 +47,7 @@ jobs:
   build-and-coverage:
     runs-on: ubuntu-latest
 
-    needs: test
+    needs: build-and-test
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
What I have done.
Merged Four jobs into two:-
- `build-lint-and-test` will first install dependencies, Lint the project and run tests.
- `build-and-coverage` will first install dependencies and then run coverage.