### PR TITLE
Enhancement: add metadata to contracts

### DIFF
--- a/contracts/lbp/LBPManager.sol
+++ b/contracts/lbp/LBPManager.sol
@@ -56,7 +56,7 @@ contract LBPManager {
     /**
      * @dev                             Initialize LBPManager.
      * @param _LBPFactory               LBP factory address.
-     * @param _beneficiary              The address that receives the _fee.
+     * @param _beneficiary              The address that receives the feePercentage.
      * @param _name                     Name of the LBP.
      * @param _symbol                   Symbol of the LBP.
      * @param _tokenList                Numerically sorted array (ascending) containing two addresses:
@@ -74,8 +74,9 @@ contract LBPManager {
      * @param _endWeights               Sorted array to match the _tokenList, containing two parametes:
                                             - The end weight for the project token in the LBP.
                                             - The end weight for the funding token in the LBP.
-
-     * @param _fee            Percentage of fee paid to _beneficiary for providing the service of the LBP Manager.
+    * @param _fees                     Array containing two parameters:
+                                            - Percentage of fee paid for every swap in the LBP.
+                                            - Percentage of fee paid to the _beneficiary for providing the service of the LBP Manager.
      * @param _metadata                 IPFS Hash of the LBP creation wizard information.
      */
     function initializeLBP(
@@ -88,8 +89,7 @@ contract LBPManager {
         uint256[] memory _startWeights,
         uint256[] memory _startTimeEndTime,
         uint256[] memory _endWeights,
-        uint256[] memory _fee,
-        // uint256 _feePercentage,
+        uint256[] memory _fees,
         bytes memory _metadata
     ) external returns (address) {
         require(!initialized, "LBPManager: already initialized");
@@ -97,7 +97,7 @@ contract LBPManager {
         {
             initialized = true;
             admin = msg.sender;
-            feePercentage = _fee[1];
+            feePercentage = _fees[1];
             beneficiary = _beneficiary;
             amounts = _amounts;
             tokenList = _tokenList;
@@ -110,7 +110,7 @@ contract LBPManager {
                     _symbol,
                     _tokenList,
                     _startWeights,
-                    _fee[0],
+                    _fees[0], // swapFeePercentage
                     address(this),
                     true // SwapEnabled is set to true at pool creation.
                 )

--- a/contracts/lbp/LBPManager.sol
+++ b/contracts/lbp/LBPManager.sol
@@ -30,9 +30,10 @@ contract LBPManager {
     address public beneficiary; // The address that recieves fees.
     uint256 public feePercentage; // Fee expressed as a % (e.g. 10**18 = 100% fee, toWei('1') = 100%)
     uint8 private projectTokenIndex; // The address of the project token.
+    uint256[] public amounts; // The amount of tokens that are going to be added as liquidity in LBP.
+    bytes public metadata; // IPFS Hash of the LBP creation wizard information.
     ILBP public lbp; // The address of LBP that is managed by this contract.
     IERC20[] public tokenList; // The tokens that are used in the LBP.
-    uint256[] public amounts; // The amount of tokens that are going to be added as liquidity in LBP.
 
     // Contract logic
     bool public poolFunded; // true:- LBP is funded; false:- LBP is yet not funded.
@@ -75,6 +76,7 @@ contract LBPManager {
                                             - The end weight for the funding token in the LBP.
      * @param _swapFeePercentage        Percentage of fee paid for every swap in the LBP.
      * @param _feePercentage            Percentage of fee paid to _beneficiary for providing the service of the LBP Manager.
+     * @param _metadata                 IPFS Hash of the LBP creation wizard information.
      */
     function initializeLBP(
         address _LBPFactory,
@@ -87,7 +89,8 @@ contract LBPManager {
         uint256[] memory _startTimeEndTime,
         uint256[] memory _endWeights,
         uint256 _swapFeePercentage,
-        uint256 _feePercentage
+        uint256 _feePercentage,
+        bytes memory _metadata
     ) external returns (address) {
         require(!initialized, "LBPManager: already initialized");
         require(_beneficiary != address(0), "LBPManager: _beneficiary is zero");
@@ -98,6 +101,7 @@ contract LBPManager {
         beneficiary = _beneficiary;
         amounts = _amounts;
         tokenList = _tokenList;
+        metadata = _metadata;
 
         lbp = ILBP(
             ILBPFactory(_LBPFactory).create(

--- a/contracts/lbp/LBPManagerFactory.sol
+++ b/contracts/lbp/LBPManagerFactory.sol
@@ -26,7 +26,7 @@ contract LBPManagerFactory is CloneFactory, Ownable {
     address public masterCopy;
     address public LBPFactory;
 
-    event LBPDeployedUsingManager(
+    event DeployLBPManager(
         address indexed lbp,
         address indexed lbpManager,
         address indexed admin
@@ -136,6 +136,6 @@ contract LBPManagerFactory is CloneFactory, Ownable {
 
         LBPManager(lbpManager).transferAdminRights(_admin);
 
-        emit LBPDeployedUsingManager(lbp, lbpManager, _admin);
+        emit DeployLBPManager(lbp, lbpManager, _admin);
     }
 }

--- a/contracts/lbp/LBPManagerFactory.sol
+++ b/contracts/lbp/LBPManagerFactory.sol
@@ -97,6 +97,7 @@ contract LBPManagerFactory is CloneFactory, Ownable {
                                             - The end weight for the funding token in the LBP.
      * @param _swapFeePercentage        Percentage of fee paid for every swap in the LBP.
      * @param _fee                      Percentage of fee paid to the _beneficiary for providing the service of the LBP Manager.
+     * @param _metaData                 IPFS Hash of the LBP creation wizard information.
      */
     function deployLBPManager(
         address _admin,
@@ -109,7 +110,8 @@ contract LBPManagerFactory is CloneFactory, Ownable {
         uint256[] memory _startTimeEndtime,
         uint256[] memory _endWeights,
         uint256 _swapFeePercentage,
-        uint256 _fee
+        uint256 _fee,
+        bytes memory _metaData
     ) external onlyOwner {
         require(
             masterCopy != address(0),
@@ -129,7 +131,8 @@ contract LBPManagerFactory is CloneFactory, Ownable {
             _startTimeEndtime,
             _endWeights,
             _swapFeePercentage,
-            _fee
+            _fee,
+            _metaData
         );
 
         LBPManager(lbpManager).transferAdminRights(_admin);

--- a/contracts/lbp/LBPManagerFactory.sol
+++ b/contracts/lbp/LBPManagerFactory.sol
@@ -77,7 +77,7 @@ contract LBPManagerFactory is CloneFactory, Ownable {
     /**
      * @dev                             Deploy and initialize LBPManager.
      * @param _admin                    The address of the admin of the LBPManager.
-     * @param _beneficiary              The address that receives the _fee.
+     * @param _beneficiary              The address that receives the _fees.
      * @param _name                     Name of the LBP.
      * @param _symbol                   Symbol of the LBP.
      * @param _tokenList                Numerically sorted array (ascending) containing two addresses:
@@ -95,8 +95,9 @@ contract LBPManagerFactory is CloneFactory, Ownable {
      * @param _endWeights               Sorted array to match the _tokenList, containing two parametes:
                                             - The end weight for the project token in the LBP.
                                             - The end weight for the funding token in the LBP.
-     * @param _swapFeePercentage        Percentage of fee paid for every swap in the LBP.
-     * @param _fee                      Percentage of fee paid to the _beneficiary for providing the service of the LBP Manager.
+     * @param _fees                     Array containing two parameters:
+                                            - Percentage of fee paid for every swap in the LBP.
+                                            - Percentage of fee paid to the _beneficiary for providing the service of the LBP Manager.
      * @param _metaData                 IPFS Hash of the LBP creation wizard information.
      */
     function deployLBPManager(
@@ -109,8 +110,7 @@ contract LBPManagerFactory is CloneFactory, Ownable {
         uint256[] memory _startWeights,
         uint256[] memory _startTimeEndtime,
         uint256[] memory _endWeights,
-        uint256 _swapFeePercentage,
-        uint256 _fee,
+        uint256[] memory _fees,
         bytes memory _metaData
     ) external onlyOwner {
         require(
@@ -130,8 +130,7 @@ contract LBPManagerFactory is CloneFactory, Ownable {
             _startWeights,
             _startTimeEndtime,
             _endWeights,
-            _swapFeePercentage,
-            _fee,
+            _fees,
             _metaData
         );
 

--- a/test/unit/lbp-manager-factory.js
+++ b/test/unit/lbp-manager-factory.js
@@ -26,7 +26,7 @@ const deploy = async () => {
   return setup;
 };
 
-describe(">> Contract: LBPManagerFactory", () => {
+describe.only(">> Contract: LBPManagerFactory", () => {
   let setup, fee, beneficiary;
   let tokenAddresses, admin, owner, sortedTokens, newLBPFactory;
 
@@ -48,12 +48,13 @@ describe(">> Contract: LBPManagerFactory", () => {
   const TO_HIGH_SWAP_FEE_PERCENTAGE = (1e18).toString();
   const ZERO_ADDRESS = constants.ZERO_ADDRESS;
   const METADATA = "0x";
+  const PRIME_FEE = 10;
 
   context("» deploy LBP LBPManagerFactory", () => {
     beforeEach("!! setup", async () => {
       setup = await deploy();
 
-      fee = 10;
+      fee = [SWAP_FEE_PERCENTAGE, 10];
 
       ({ root: owner, prime: admin, beneficiary: beneficiary } = setup.roles);
 
@@ -78,6 +79,7 @@ describe(">> Contract: LBPManagerFactory", () => {
   context("» set MasterCopy of LBPManager", () => {
     let params;
     before("!! setup for deploying LBPManager", async () => {
+      fee = [SWAP_FEE_PERCENTAGE, PRIME_FEE];
       params = [
         admin.address,
         beneficiary.address,
@@ -88,7 +90,6 @@ describe(">> Contract: LBPManagerFactory", () => {
         START_WEIGHTS,
         [startTime, endTime],
         END_WEIGHTS,
-        SWAP_FEE_PERCENTAGE,
         fee,
         METADATA,
       ];
@@ -153,6 +154,7 @@ describe(">> Contract: LBPManagerFactory", () => {
   context("» deploy LBP using LBPManager with wrong values", () => {
     let params;
     it("$ reverts on invalid swapFeePercentage", async () => {
+      fee = [TO_LOW_SWAP_FEE_PERCENTAGE, PRIME_FEE];
       params = [
         admin.address,
         beneficiary.address,
@@ -163,7 +165,6 @@ describe(">> Contract: LBPManagerFactory", () => {
         START_WEIGHTS,
         [startTime, endTime],
         END_WEIGHTS,
-        TO_LOW_SWAP_FEE_PERCENTAGE,
         fee,
         METADATA,
       ];
@@ -172,7 +173,7 @@ describe(">> Contract: LBPManagerFactory", () => {
       ).to.be.revertedWith(
         "BAL#203" //MIN_SWAP_FEE_PERCENTAGE
       );
-
+      fee = [TO_HIGH_SWAP_FEE_PERCENTAGE, PRIME_FEE];
       params = [
         admin.address,
         beneficiary.address,
@@ -183,7 +184,6 @@ describe(">> Contract: LBPManagerFactory", () => {
         START_WEIGHTS,
         [startTime, endTime],
         END_WEIGHTS,
-        TO_HIGH_SWAP_FEE_PERCENTAGE,
         fee,
         METADATA,
       ];
@@ -194,6 +194,7 @@ describe(">> Contract: LBPManagerFactory", () => {
       );
     });
     it("$ reverts on invalid beneficiary address", async () => {
+      fee = [SWAP_FEE_PERCENTAGE_CHANGED, PRIME_FEE];
       params = [
         admin.address,
         ZERO_ADDRESS,
@@ -204,7 +205,6 @@ describe(">> Contract: LBPManagerFactory", () => {
         START_WEIGHTS,
         [startTime, endTime],
         END_WEIGHTS,
-        SWAP_FEE_PERCENTAGE_CHANGED,
         fee,
         METADATA,
       ];
@@ -228,7 +228,6 @@ describe(">> Contract: LBPManagerFactory", () => {
         START_WEIGHTS,
         [startTime, endTime],
         END_WEIGHTS,
-        SWAP_FEE_PERCENTAGE_CHANGED,
         fee,
         METADATA,
       ];
@@ -250,7 +249,6 @@ describe(">> Contract: LBPManagerFactory", () => {
         START_WEIGHTS,
         [startTime, endTime],
         END_WEIGHTS,
-        SWAP_FEE_PERCENTAGE_CHANGED,
         fee,
         METADATA,
       ];

--- a/test/unit/lbp-manager-factory.js
+++ b/test/unit/lbp-manager-factory.js
@@ -26,8 +26,8 @@ const deploy = async () => {
   return setup;
 };
 
-describe.only(">> Contract: LBPManagerFactory", () => {
-  let setup, fee, beneficiary;
+describe(">> Contract: LBPManagerFactory", () => {
+  let setup, fees, beneficiary;
   let tokenAddresses, admin, owner, sortedTokens, newLBPFactory;
 
   const startTime = Date.now();
@@ -54,7 +54,7 @@ describe.only(">> Contract: LBPManagerFactory", () => {
     beforeEach("!! setup", async () => {
       setup = await deploy();
 
-      fee = [SWAP_FEE_PERCENTAGE, 10];
+      fees = [SWAP_FEE_PERCENTAGE, 10];
 
       ({ root: owner, prime: admin, beneficiary: beneficiary } = setup.roles);
 
@@ -79,7 +79,7 @@ describe.only(">> Contract: LBPManagerFactory", () => {
   context("» set MasterCopy of LBPManager", () => {
     let params;
     before("!! setup for deploying LBPManager", async () => {
-      fee = [SWAP_FEE_PERCENTAGE, PRIME_FEE];
+      fees = [SWAP_FEE_PERCENTAGE, PRIME_FEE];
       params = [
         admin.address,
         beneficiary.address,
@@ -90,7 +90,7 @@ describe.only(">> Contract: LBPManagerFactory", () => {
         START_WEIGHTS,
         [startTime, endTime],
         END_WEIGHTS,
-        fee,
+        fees,
         METADATA,
       ];
     });
@@ -154,7 +154,7 @@ describe.only(">> Contract: LBPManagerFactory", () => {
   context("» deploy LBP using LBPManager with wrong values", () => {
     let params;
     it("$ reverts on invalid swapFeePercentage", async () => {
-      fee = [TO_LOW_SWAP_FEE_PERCENTAGE, PRIME_FEE];
+      fees = [TO_LOW_SWAP_FEE_PERCENTAGE, PRIME_FEE];
       params = [
         admin.address,
         beneficiary.address,
@@ -165,7 +165,7 @@ describe.only(">> Contract: LBPManagerFactory", () => {
         START_WEIGHTS,
         [startTime, endTime],
         END_WEIGHTS,
-        fee,
+        fees,
         METADATA,
       ];
       await expect(
@@ -173,7 +173,7 @@ describe.only(">> Contract: LBPManagerFactory", () => {
       ).to.be.revertedWith(
         "BAL#203" //MIN_SWAP_FEE_PERCENTAGE
       );
-      fee = [TO_HIGH_SWAP_FEE_PERCENTAGE, PRIME_FEE];
+      fees = [TO_HIGH_SWAP_FEE_PERCENTAGE, PRIME_FEE];
       params = [
         admin.address,
         beneficiary.address,
@@ -184,7 +184,7 @@ describe.only(">> Contract: LBPManagerFactory", () => {
         START_WEIGHTS,
         [startTime, endTime],
         END_WEIGHTS,
-        fee,
+        fees,
         METADATA,
       ];
       await expect(
@@ -194,7 +194,7 @@ describe.only(">> Contract: LBPManagerFactory", () => {
       );
     });
     it("$ reverts on invalid beneficiary address", async () => {
-      fee = [SWAP_FEE_PERCENTAGE_CHANGED, PRIME_FEE];
+      fees = [SWAP_FEE_PERCENTAGE_CHANGED, PRIME_FEE];
       params = [
         admin.address,
         ZERO_ADDRESS,
@@ -205,7 +205,7 @@ describe.only(">> Contract: LBPManagerFactory", () => {
         START_WEIGHTS,
         [startTime, endTime],
         END_WEIGHTS,
-        fee,
+        fees,
         METADATA,
       ];
       await expect(
@@ -228,7 +228,7 @@ describe.only(">> Contract: LBPManagerFactory", () => {
         START_WEIGHTS,
         [startTime, endTime],
         END_WEIGHTS,
-        fee,
+        fees,
         METADATA,
       ];
       await expect(
@@ -249,7 +249,7 @@ describe.only(">> Contract: LBPManagerFactory", () => {
         START_WEIGHTS,
         [startTime, endTime],
         END_WEIGHTS,
-        fee,
+        fees,
         METADATA,
       ];
     });

--- a/test/unit/lbp-manager-factory.js
+++ b/test/unit/lbp-manager-factory.js
@@ -47,6 +47,7 @@ describe(">> Contract: LBPManagerFactory", () => {
   const TO_LOW_SWAP_FEE_PERCENTAGE = 1e10;
   const TO_HIGH_SWAP_FEE_PERCENTAGE = (1e18).toString();
   const ZERO_ADDRESS = constants.ZERO_ADDRESS;
+  const METADATA = "0x";
 
   context("» deploy LBP LBPManagerFactory", () => {
     beforeEach("!! setup", async () => {
@@ -89,6 +90,7 @@ describe(">> Contract: LBPManagerFactory", () => {
         END_WEIGHTS,
         SWAP_FEE_PERCENTAGE,
         fee,
+        METADATA,
       ];
     });
     it("$ reverts if deploying LBPManager & mastercopy is not set", async () => {
@@ -163,6 +165,7 @@ describe(">> Contract: LBPManagerFactory", () => {
         END_WEIGHTS,
         TO_LOW_SWAP_FEE_PERCENTAGE,
         fee,
+        METADATA,
       ];
       await expect(
         setup.lbpManagerFactory.connect(owner).deployLBPManager(...params)
@@ -182,6 +185,7 @@ describe(">> Contract: LBPManagerFactory", () => {
         END_WEIGHTS,
         TO_HIGH_SWAP_FEE_PERCENTAGE,
         fee,
+        METADATA,
       ];
       await expect(
         setup.lbpManagerFactory.connect(owner).deployLBPManager(...params)
@@ -202,6 +206,7 @@ describe(">> Contract: LBPManagerFactory", () => {
         END_WEIGHTS,
         SWAP_FEE_PERCENTAGE_CHANGED,
         fee,
+        METADATA,
       ];
       await expect(
         setup.lbpManagerFactory.connect(owner).deployLBPManager(...params)
@@ -225,6 +230,7 @@ describe(">> Contract: LBPManagerFactory", () => {
         END_WEIGHTS,
         SWAP_FEE_PERCENTAGE_CHANGED,
         fee,
+        METADATA,
       ];
       await expect(
         setup.lbpManagerFactory.connect(owner).deployLBPManager(...params)
@@ -246,6 +252,7 @@ describe(">> Contract: LBPManagerFactory", () => {
         END_WEIGHTS,
         SWAP_FEE_PERCENTAGE_CHANGED,
         fee,
+        METADATA,
       ];
     });
     it("$ deploys LBP successful", async () => {

--- a/test/unit/lbp-manager-factory.js
+++ b/test/unit/lbp-manager-factory.js
@@ -260,7 +260,7 @@ describe(">> Contract: LBPManagerFactory", () => {
       const receipt = await tx.wait();
 
       const args = receipt.events.filter((data) => {
-        return data.event === "LBPDeployedUsingManager";
+        return data.event === "DeployLBPManager";
       })[0].args;
 
       setup.lbp = setup.Lbp.attach(args.lbp);

--- a/test/unit/lbp-manager.js
+++ b/test/unit/lbp-manager.js
@@ -54,8 +54,7 @@ paramGenerator.initializeParams = (
   startTime,
   endTime,
   endWeights,
-  swapFee,
-  fee,
+  fees,
   beneficiary,
   METADATA
 ) => [
@@ -68,8 +67,7 @@ paramGenerator.initializeParams = (
   startWeights,
   [startTime, endTime],
   endWeights,
-  swapFee,
-  fee,
+  fees,
   METADATA,
 ];
 
@@ -175,7 +173,7 @@ const setupInitialState = async (contractInstances, initialState) => {
   };
 };
 
-describe.only(">> Contract: LBPManager", () => {
+describe(">> Contract: LBPManager", () => {
   let poolId,
     admin,
     owner,
@@ -188,7 +186,8 @@ describe.only(">> Contract: LBPManager", () => {
     tokenInstances,
     lbpContractFactory,
     lbpInstance,
-    tokenAddresses;
+    tokenAddresses,
+    fees;
 
   const NAME = "Test";
   const SYMBOL = "TT";
@@ -225,6 +224,8 @@ describe.only(">> Contract: LBPManager", () => {
 
     tokenAddresses = tokenInstances.map((token) => token.address);
 
+    fees = [SWAP_FEE_PERCENTAGE, FEE_PERCENTAGE_ZERO];
+
     initializeLBPParams = paramGenerator.initializeParams(
       lbpFactoryInstance.address,
       NAME,
@@ -235,8 +236,7 @@ describe.only(">> Contract: LBPManager", () => {
       startTime,
       endTime,
       END_WEIGHTS,
-      SWAP_FEE_PERCENTAGE,
-      FEE_PERCENTAGE_ZERO,
+      fees,
       beneficiary.address,
       METADATA
     );
@@ -247,6 +247,7 @@ describe.only(">> Contract: LBPManager", () => {
       let invalidInitializeLBPParams;
 
       it("» revert on swap fee to high", async () => {
+        fees = [TO_HIGH_SWAP_FEE_PERCENTAGE, FEE_PERCENTAGE_ZERO];
         invalidInitializeLBPParams = paramGenerator.initializeParams(
           lbpFactoryInstance.address,
           NAME,
@@ -257,8 +258,7 @@ describe.only(">> Contract: LBPManager", () => {
           startTime,
           endTime,
           END_WEIGHTS,
-          TO_HIGH_SWAP_FEE_PERCENTAGE,
-          FEE_PERCENTAGE_ZERO,
+          fees,
           beneficiary.address,
           METADATA
         );
@@ -271,6 +271,7 @@ describe.only(">> Contract: LBPManager", () => {
         );
       });
       it("» revert on swap fee to low", async () => {
+        fees = [TO_LOW_SWAP_FEE_PERCENTAGE, FEE_PERCENTAGE_ZERO];
         invalidInitializeLBPParams = paramGenerator.initializeParams(
           lbpFactoryInstance.address,
           NAME,
@@ -281,8 +282,7 @@ describe.only(">> Contract: LBPManager", () => {
           startTime,
           endTime,
           END_WEIGHTS,
-          TO_LOW_SWAP_FEE_PERCENTAGE,
-          FEE_PERCENTAGE_ZERO,
+          fees,
           beneficiary.address,
           METADATA
         );
@@ -305,8 +305,7 @@ describe.only(">> Contract: LBPManager", () => {
           startTime,
           endTime,
           END_WEIGHTS,
-          SWAP_FEE_PERCENTAGE,
-          FEE_PERCENTAGE_ZERO,
+          fees,
           ZERO_ADDRESS,
           METADATA
         );
@@ -332,8 +331,7 @@ describe.only(">> Contract: LBPManager", () => {
           startTime,
           endTime,
           END_WEIGHTS,
-          SWAP_FEE_PERCENTAGE,
-          FEE_PERCENTAGE_ZERO,
+          fees,
           beneficiary.address,
           METADATA
         );
@@ -426,6 +424,7 @@ describe.only(">> Contract: LBPManager", () => {
     });
     describe("$ calculate with five percent", () => {
       beforeEach(async () => {
+        fees = [SWAP_FEE_PERCENTAGE, FEE_PERCENTAGE_FIVE];
         initializeLBPParams = paramGenerator.initializeParams(
           lbpFactoryInstance.address,
           NAME,
@@ -436,8 +435,7 @@ describe.only(">> Contract: LBPManager", () => {
           startTime,
           endTime,
           END_WEIGHTS,
-          SWAP_FEE_PERCENTAGE,
-          FEE_PERCENTAGE_FIVE,
+          fees,
           beneficiary.address,
           METADATA
         );
@@ -524,6 +522,8 @@ describe.only(">> Contract: LBPManager", () => {
       let userData, amountToAddForFee;
 
       beforeEach(async () => {
+        fees = [SWAP_FEE_PERCENTAGE, FEE_PERCENTAGE_FIVE];
+
         initializeLBPParams = paramGenerator.initializeParams(
           lbpFactoryInstance.address,
           NAME,
@@ -534,8 +534,7 @@ describe.only(">> Contract: LBPManager", () => {
           startTime,
           endTime,
           END_WEIGHTS,
-          SWAP_FEE_PERCENTAGE,
-          FEE_PERCENTAGE_FIVE,
+          fees,
           beneficiary.address,
           METADATA
         );
@@ -605,6 +604,8 @@ describe.only(">> Contract: LBPManager", () => {
       let userData, amountToAddForFee;
 
       beforeEach(async () => {
+        fees = [SWAP_FEE_PERCENTAGE, FEE_PERCENTAGE_ONE];
+
         initializeLBPParams = paramGenerator.initializeParams(
           lbpFactoryInstance.address,
           NAME,
@@ -615,8 +616,7 @@ describe.only(">> Contract: LBPManager", () => {
           startTime,
           endTime,
           END_WEIGHTS,
-          SWAP_FEE_PERCENTAGE,
-          FEE_PERCENTAGE_ONE,
+          fees,
           beneficiary.address,
           METADATA
         );
@@ -758,6 +758,7 @@ describe.only(">> Contract: LBPManager", () => {
         const reverseInitialBalance = reverseArray(INITIAL_BALANCES);
         const reverseWeights = reverseArray(START_WEIGHTS);
         const reverseEndWeights = reverseArray(END_WEIGHTS);
+        fees = [SWAP_FEE_PERCENTAGE, FEE_PERCENTAGE_FIVE];
 
         initializeLBPParams = paramGenerator.initializeParams(
           lbpFactoryInstance.address,
@@ -769,8 +770,7 @@ describe.only(">> Contract: LBPManager", () => {
           startTime,
           endTime,
           reverseEndWeights,
-          SWAP_FEE_PERCENTAGE,
-          FEE_PERCENTAGE_FIVE,
+          fees,
           beneficiary.address,
           METADATA
         );
@@ -854,8 +854,7 @@ describe.only(">> Contract: LBPManager", () => {
           startTime,
           endTime,
           reverseEndWeights,
-          SWAP_FEE_PERCENTAGE,
-          FEE_PERCENTAGE_ZERO,
+          fees,
           beneficiary.address,
           METADATA
         );

--- a/test/unit/lbp-manager.js
+++ b/test/unit/lbp-manager.js
@@ -175,7 +175,7 @@ const setupInitialState = async (contractInstances, initialState) => {
   };
 };
 
-describe(">> Contract: LBPManager", () => {
+describe.only(">> Contract: LBPManager", () => {
   let poolId,
     admin,
     owner,

--- a/test/unit/lbp-manager.js
+++ b/test/unit/lbp-manager.js
@@ -55,8 +55,9 @@ paramGenerator.initializeParams = (
   endTime,
   endWeights,
   swapFee,
-  primeFee,
-  beneficiary
+  fee,
+  beneficiary,
+  METADATA
 ) => [
   factory,
   beneficiary,
@@ -68,7 +69,8 @@ paramGenerator.initializeParams = (
   [startTime, endTime],
   endWeights,
   swapFee,
-  primeFee,
+  fee,
+  METADATA,
 ];
 
 const setupInitialState = async (contractInstances, initialState) => {
@@ -200,6 +202,7 @@ describe(">> Contract: LBPManager", () => {
   const FEE_PERCENTAGE_FIVE = parseUnits("5", 17);
   const FEE_PERCENTAGE_ONE = parseUnits("1", 17);
   const FEE_PERCENTAGE_ZERO = 0;
+  const METADATA = "0x7B502C3A1F48C8609AE212CDFB639DEE39673F5E"; // Random hash string
 
   let startTime = Math.floor(Date.now() / 1000);
   let endTime = startTime + 1000;
@@ -234,7 +237,8 @@ describe(">> Contract: LBPManager", () => {
       END_WEIGHTS,
       SWAP_FEE_PERCENTAGE,
       FEE_PERCENTAGE_ZERO,
-      beneficiary.address
+      beneficiary.address,
+      METADATA
     );
   });
 
@@ -255,7 +259,8 @@ describe(">> Contract: LBPManager", () => {
           END_WEIGHTS,
           TO_HIGH_SWAP_FEE_PERCENTAGE,
           FEE_PERCENTAGE_ZERO,
-          beneficiary.address
+          beneficiary.address,
+          METADATA
         );
         await expect(
           lbpManagerInstance
@@ -278,7 +283,8 @@ describe(">> Contract: LBPManager", () => {
           END_WEIGHTS,
           TO_LOW_SWAP_FEE_PERCENTAGE,
           FEE_PERCENTAGE_ZERO,
-          beneficiary.address
+          beneficiary.address,
+          METADATA
         );
         await expect(
           lbpManagerInstance
@@ -301,7 +307,8 @@ describe(">> Contract: LBPManager", () => {
           END_WEIGHTS,
           SWAP_FEE_PERCENTAGE,
           FEE_PERCENTAGE_ZERO,
-          ZERO_ADDRESS
+          ZERO_ADDRESS,
+          METADATA
         );
         await expect(
           lbpManagerInstance
@@ -327,7 +334,8 @@ describe(">> Contract: LBPManager", () => {
           END_WEIGHTS,
           SWAP_FEE_PERCENTAGE,
           FEE_PERCENTAGE_ZERO,
-          beneficiary.address
+          beneficiary.address,
+          METADATA
         );
         await expect(
           lbpManagerInstance
@@ -350,6 +358,9 @@ describe(">> Contract: LBPManager", () => {
         );
         expect(await lbpManagerInstance.feePercentage()).to.equal(
           FEE_PERCENTAGE_ZERO
+        );
+        expect(await lbpManagerInstance.metadata()).to.equal(
+          METADATA.toLowerCase()
         );
       });
       it("» reverts when invoking it again", async () => {
@@ -427,7 +438,8 @@ describe(">> Contract: LBPManager", () => {
           END_WEIGHTS,
           SWAP_FEE_PERCENTAGE,
           FEE_PERCENTAGE_FIVE,
-          beneficiary.address
+          beneficiary.address,
+          METADATA
         );
         projectTokenIndex = 0;
 
@@ -524,7 +536,8 @@ describe(">> Contract: LBPManager", () => {
           END_WEIGHTS,
           SWAP_FEE_PERCENTAGE,
           FEE_PERCENTAGE_FIVE,
-          beneficiary.address
+          beneficiary.address,
+          METADATA
         );
 
         userData = ethers.utils.defaultAbiCoder.encode(
@@ -604,7 +617,8 @@ describe(">> Contract: LBPManager", () => {
           END_WEIGHTS,
           SWAP_FEE_PERCENTAGE,
           FEE_PERCENTAGE_ONE,
-          beneficiary.address
+          beneficiary.address,
+          METADATA
         );
 
         userData = ethers.utils.defaultAbiCoder.encode(
@@ -757,7 +771,8 @@ describe(">> Contract: LBPManager", () => {
           reverseEndWeights,
           SWAP_FEE_PERCENTAGE,
           FEE_PERCENTAGE_FIVE,
-          beneficiary.address
+          beneficiary.address,
+          METADATA
         );
 
         userData = ethers.utils.defaultAbiCoder.encode(
@@ -841,7 +856,8 @@ describe(">> Contract: LBPManager", () => {
           reverseEndWeights,
           SWAP_FEE_PERCENTAGE,
           FEE_PERCENTAGE_ZERO,
-          beneficiary.address
+          beneficiary.address,
+          METADATA
         );
 
         userData = ethers.utils.defaultAbiCoder.encode(


### PR DESCRIPTION
## What have I done?
- Added `metadata` to `LBPManagerFactory` and `LBPManager`.
- Merged `_swapFeePercentage` and `_fee` into one array because of `stack to deep` error from the EVM.
- Adjusted tests accordingly

closes #154 